### PR TITLE
Fix MongoDB connection error in Synology scripts

### DIFF
--- a/scripts/synology/checkDatabase.js
+++ b/scripts/synology/checkDatabase.js
@@ -2,7 +2,7 @@ const path = require('path');
 const { MongoClient } = require(path.join(__dirname, '../../backend/node_modules/mongodb'));
 
 // MongoDB 연결 설정 - 시놀로지 Docker 환경 (단일 노드 연결)
-const url = 'mongodb://hr_app_user:Hr2025Secure@localhost:27018/SM_nomu?authSource=SM_nomu';
+const url = 'mongodb://hr_app_user:Hr2025Secure@localhost:27018/SM_nomu?authSource=SM_nomu&directConnection=true';
 const dbName = 'SM_nomu';
 
 async function checkDatabase() {

--- a/scripts/synology/createAdmin.js
+++ b/scripts/synology/createAdmin.js
@@ -3,7 +3,7 @@ const { MongoClient } = require(path.join(__dirname, '../../backend/node_modules
 const bcrypt = require(path.join(__dirname, '../../backend/node_modules/bcryptjs'));
 
 // MongoDB 연결 설정 - 시놀로지 Docker 환경 (단일 노드 연결)
-const url = 'mongodb://hr_app_user:Hr2025Secure@localhost:27018/SM_nomu?authSource=SM_nomu';
+const url = 'mongodb://hr_app_user:Hr2025Secure@localhost:27018/SM_nomu?authSource=SM_nomu&directConnection=true';
 const dbName = 'SM_nomu';
 
 async function createAdminUser() {

--- a/scripts/synology/resetDatabase.js
+++ b/scripts/synology/resetDatabase.js
@@ -3,7 +3,7 @@ const { MongoClient } = require(path.join(__dirname, '../../backend/node_modules
 const bcrypt = require(path.join(__dirname, '../../backend/node_modules/bcryptjs'));
 
 // MongoDB 연결 설정 - 시놀로지 Docker 환경 (단일 노드 연결)
-const url = 'mongodb://hr_app_user:Hr2025Secure@localhost:27018/SM_nomu?authSource=SM_nomu';
+const url = 'mongodb://hr_app_user:Hr2025Secure@localhost:27018/SM_nomu?authSource=SM_nomu&directConnection=true';
 const dbName = 'SM_nomu';
 
 async function resetDatabase() {


### PR DESCRIPTION
Add directConnection=true to MongoDB connection strings to prevent
replica set hostname resolution issues when connecting from outside
Docker network.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>